### PR TITLE
Fix Python version formatting in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Quote Python version numbers in test.yml matrix to prevent YAML float conversion
- Fixes error: 'The version '3.1' with architecture 'x64' was not found'
- Python '3.10' was being interpreted as float 3.1 instead of string '3.10'

🤖 Generated with [Claude Code](https://claude.ai/code)